### PR TITLE
Create BarcodeValidator.php to fix Composer autoload

### DIFF
--- a/src/BarcodeValidator.php
+++ b/src/BarcodeValidator.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Autoload helper for BarcodeValidator.
+ *
+ * Since the \BarcodeValidator class is written in barcode-validator.php, it
+ * cannot be auto-loaded with Composer. This file helps meet the naming
+ * convention requirements to facilitate autoload.
+ *
+ * @todo Rename barcode-validator.php to BarcodeValidator.php.
+ */
+
+require 'barcode-validator.php';


### PR DESCRIPTION
Since the `\BarcodeValidator` class is written in `barcode-validator.php`, it cannot be auto-loaded with Composer. This file helps meet the naming convention requirements to facilitate autoload.

Fixes https://github.com/imelgrat/barcode-validator/issues/7

I didn't rename the file because it is referred several times in the `docs` directory. Someone with more knowledge of the project should be in a better position to rename the file correctly.